### PR TITLE
Makefile: find a better means of getting java version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ LWIP?=$(HOME)/src/lwip
 CFLAGS=-fno-stack-protector -Wall -O2 -g -D_GNU_SOURCE -fPIC
 CFLAGS+=-I$(LWIP)/src/include/ipv4 -I$(LWIP)/src/include/ipv6
 CFLAGS+=-I$(LWIP)/src/include
-JAVA_32=$(shell java -version 2>&1 | grep -q "32-Bit" && echo -m32)
+JAVA_32=$(shell java -d64 -version 2>&1 |\
+	 grep -q "is not supported on this platform" && echo -m32)
 
 LIB_SOURCES=\
 fd.c \


### PR DESCRIPTION
http://stackoverflow.com/questions/2062020/how-can-i-tell-if-im-running-in-64-bit-jvm-or-32-bit-jvm-from-within-a-program

Currently using Sun JDK 32 bit install, java -version shows:
$ java -version
java version "1.6.0_45"
Java(TM) SE Runtime Environment (build 1.6.0_45-b06)
Java HotSpot(TM) Client VM (build 20.45-b01, mixed mode, sharing)

$ java -d64 -version
Running a 64-bit JVM is not supported on this platform.

Expecting "32-bit" in string does not seem supported in all Java installations!

Signed-off-by: Nishanth Menon nm@ti.com
